### PR TITLE
Support running docker-compose in a server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
       NEO4J_HOST: "neo4j"
     restart: always
     volumes:
-      - "neo4jstorage:/bitname"
+      - "neo4jstorage:/bitnami"
     networks:
       - default
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - kafka
     command: *base-kafka-command
     environment: *base-environment
+    restart: always
     networks:
       - nosy-cat
       - default
@@ -71,6 +72,7 @@ services:
       - graph-service
       - kafka
     environment: *base-environment
+    restart: always
     networks:
       - default
 
@@ -99,6 +101,8 @@ services:
       TIME_UNIT_IN_MS: 10000
       USE_INFLUX: "true"
       INFLUX_URL: http://influxdb:8086
+      LOG_LEVEL: info
+    restart: always
     networks:
       - default
 
@@ -120,6 +124,7 @@ services:
       - kafka
     environment:
       <<: *base-environment
+    restart: always
     networks:
       - default
 
@@ -146,6 +151,7 @@ services:
       <<: *base-environment
       NEO4J_HOST: neo4j://neo4j:7687
       NEO4J_STATUS: http://neo4j:7474
+    restart: always
     networks:
       - default
 
@@ -167,13 +173,11 @@ services:
       # Advertise domain instead of ip so that calls from other containers and the host machine do a different
       # dns resolution (docker container ip  for other containers, localhost for browser as the ports are exposed)
       NEO4J_HOST: "neo4j"
+    restart: always
+    volumes:
+      - "neo4jstorage:/bitname"
     networks:
       - default
-
-  browser-proxy:
-    image: nginx:1.17
-    ports:
-      - "80:80"
 
   pagerduty-integration:
     build:
@@ -188,6 +192,7 @@ services:
       - "./pagerduty-integration/tsconfig.json:/project/app/tsconfig.json"
       - "./pagerduty-integration/src:/project/app/src"
     command: *base-kafka-command
+    restart: always
     depends_on:
       - kafka
     environment:
@@ -197,6 +202,7 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper
+    restart: always
     expose:
       - "2181"
     networks:
@@ -215,6 +221,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_BROKER_ID: 1
+    restart: always
     networks:
       - default
 
@@ -245,15 +252,6 @@ services:
     networks:
       - default
 
-  redis-insight:
-    image: redislabs/redisinsight
-    ports:
-      - "8001:8001"
-    depends_on:
-      - redis
-    networks:
-      - default
-
   influxdb:
     image: influxdb:2.0
     environment:
@@ -266,6 +264,8 @@ services:
       - *influx-token-volume
       - "./influxdb/setup.sh:/docker-entrypoint-initdb.d/setup.sh"
       - "./influxdb/template.yml:/home/influxdb/template.yml"
+      # - "influxdbstorage:/var/lib/influxdb2"
+    restart: always
     ports:
       - "8086:8086"
     depends_on:
@@ -293,3 +293,5 @@ networks:
 
 volumes:
   influxdbtoken:
+  influxdbstorage:
+  neo4jstorage:

--- a/helpers/src/logger.ts
+++ b/helpers/src/logger.ts
@@ -34,7 +34,7 @@ const logger = winston.createLogger({
     winston.format.printf((info: winston.LogEntry) => `${info.timestamp} - ${info.level}: ${info.message}`)
   ),
   transports: [new winston.transports.Console()],
-  level: process.env.NODE_ENV === "test" ? "error" : "silly",
+  level: process.env.LOG_LEVEL || (process.env.NODE_ENV === "test" ? "error" : "silly"),
 });
 
 // logger.error("hello");

--- a/metrics-processor/src/app.ts
+++ b/metrics-processor/src/app.ts
@@ -15,7 +15,7 @@ consume(tracer, "ingress", onEachMessage);
 // ---
 
 async function processSpan(span: ZipkinSpan): Promise<ComponentHistoricMetrics | null> {
-  logger.info(`processing span ${JSON.stringify(span, null, 4)}`);
+  logger.debug(`processing span ${JSON.stringify(span, null, 4)}`);
   const errored = hasErrored(span);
   const remoteEndpointName = (span.remoteEndpoint && span.remoteEndpoint.serviceName) || undefined;
   const localEndpointName = (span.localEndpoint && span.localEndpoint.serviceName) || undefined;

--- a/metrics-processor/src/influxRepository.ts
+++ b/metrics-processor/src/influxRepository.ts
@@ -26,7 +26,7 @@ class InfluxRepository implements MetricsRepository {
         logger.error(`There was an error writing to Influx: ${error.stack}`);
       },
       writeSuccess: (lines: string[]) => {
-        logger.debug(`Successfully wrote ${lines.length} lines to Influx :)`);
+        logger.info(`Successfully wrote ${lines.length} lines to Influx :)`);
       },
       flushInterval: parseInt(process.env.INFLUX_FLUSH_INTERVAL_MS || "60000", 10),
     });

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Install Docker
+yum update -y
+amazon-linux-extras install docker
+service docker start
+usermod -a -G docker ec2-user
+
+# Install Docker-Compose
+curl -L "https://github.com/docker/compose/releases/download/1.28.6/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod 0555 /usr/local/bin/docker-compose
+export PATH=$PATH:/local/bin
+echo 'export PATH=$PATH:/local/bin' >> /home/ec2-user/.bashrc
+
+# Customizations :)
+echo 'alias docc=docker-compose' >> /home/ec2-user/.bashrc
+
+# Install Git & Clone Repo
+yum install git -y
+cd /home/ec2-user
+git clone https://github.com/toblich/nosy-cat.git
+
+# Start everything
+chown -R ec2-user nosy-cat
+cd nosy-cat/
+docker-compose up -d


### PR DESCRIPTION
- All services auto-restart and have persistent storage where needed.
- Add `user data` script meant for AWS to automatically bootstrap everything in an EC2 instance (recommended type: `t3.large` to run everything in that one server, which isn't production-ready but it is convenient for demo purposes and cost-effective).
- Remove unused services from docker-compose.